### PR TITLE
Simplify fat jar creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,6 @@
           <artifactId>jline</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
@@ -64,12 +60,6 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>${curator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZookeeperClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZookeeperClusterManager.java
@@ -59,6 +59,7 @@ public class ZookeeperClusterManager implements ClusterManager, PathChildrenCach
 
   public ZookeeperClusterManager() {
     if (conf == null) {
+      conf = new Properties();
       InputStream is = getConfigStream();
       try {
         conf.load(is);

--- a/src/main/resources/META-INF/services/io.vertx.core.spi.cluster.ClusterManager
+++ b/src/main/resources/META-INF/services/io.vertx.core.spi.cluster.ClusterManager
@@ -1,0 +1,1 @@
+io.vertx.spi.cluster.impl.zookeeper.ZookeeperClusterManager

--- a/src/main/resources/services/io.vertx.core.spi.cluster.ClusterManager
+++ b/src/main/resources/services/io.vertx.core.spi.cluster.ClusterManager
@@ -1,1 +1,0 @@
-io.vertx.spi.cluster.impl.ZookeeperClusterManager


### PR DESCRIPTION
I've changed a bit how the cluster manager is packaged to be usabled in a _fat jar_.

* Fix SPI file location and class name
* Fix NPE in constructor
* The slf4j dependency should be in the `compile` scope as the user fat jar need to embed it