### PR TITLE
Set ZK conf with Sys prop, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ you can also put all the jar (with out shaded) into `$VERTX_HOME/lib` by yoursel
 - change the value of `-Dvertx.cluster.managerClass=` to `io.vertx.spi.cluster.impl.zookeeper.ZookeeperClusterManager` in`$VERTX_HOME/bin/vertx`
 - make sure you have running zookeeper server.
 - put zookeeper.properties into $VERTX_HOME/conf, you can find default-zookeeper.properties as [example](https://github.com/stream1984/vertx-zookeeper/blob/master/src/main/resources/default-zookeeper.properties)
+- use the flag `-Dvertx.zookeeper.conf=` to set the `zookeeper.properties` file if it is not in the classpath. ie `-Dvertx.zookeeper.conf=/etc/app/zookeeper.properties`
 - then run your verticle with cmd `vertx -cluster`
 
 #### Add to your Vertx Application
@@ -60,7 +61,7 @@ Gradle:
 
 Be sure to set System Properties:
  - `-Dvertx.cluster.managerClass=io.vertx.spi.cluster.impl.zookeeper.ZookeeperClusterManager`
- - `-Dvertx.zookeeper.properties=/path/to/file/zookeeper.properties`
+ - `-Dvertx.zookeeper.conf=/path/to/file/zookeeper.properties`
 
 #### Create a Cluster Vertx programmatically 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zookeeper Vert.x Cluster Manager
 Using zookeeper as vert.x cluster manager, implements interfaces of vert.x cluster totally.
-So you can using it to instead of vertx-hazelcast if you wanna.  
+So you can using it to instead of vertx-hazelcast if you want.  
   
 In Vert.x a cluster manager is used for various functions including:
 - Discovery and group membership of Vert.x nodes in a cluster
@@ -12,8 +12,8 @@ In Vert.x a cluster manager is used for various functions including:
 Cluster managers `do not` handle the event bus inter-node transport, this is done directly by Vert.x with TCP connections.
 
 ## How to work
-We using [curator](http://curator.apache.org/) framework rather than zookeeper client directly, so  
-you would find we also dependency library that curator's such as `guava`, `slf4j` and of course `zookeeper`.  
+We are using [Apache Curator](http://curator.apache.org/) framework rather than zookeeper client directly, so  
+ we have a dependency for libraries used in Curator such as `guava`, `slf4j` and of course `zookeeper`.  
 
 Since ZK using tree dictionary to store data, we can take root path as namespace default root path is `io.vertx` which in default-zookeeper.properties.  
 and there are another 5 sub path to record other information for functions in vert.x cluster manager, all you can change the path is `root path`.  
@@ -28,21 +28,43 @@ you can find all the vert.x node information in path of `/io.vertx/cluster/nodes
 we could also find how many `EventBus` register with an eventbus address in ZK path`io.vertx/asyncMultiMap/subs/$busAddress/`, so we have view that could 
 look up all eventbus with it address through zk cli or WebUI.
 
-#### Using this cluster manager
+#### Using this cluster manager with Vertx CLI
 If you are using Vert.x from the command line, the jar corresponding to this cluster manager 
 (it will be named `vertx-zookeeper-${version}-shaded.jar` should be in the lib directory of the Vert.x installation.
 you can also put all the jar (with out shaded) into `$VERTX_HOME/lib` by yourself with following step.
 
 - execution `mvn package -Dmaven.test.skip=true` and copy `target/vertx-zookeeper-$version/lib/*.jar` or just only `target/`vertx-zookeeper-${version}-shaded.jar` into $VERTX_HOME/lib
-- change the value of `-Dvertx.clusterManagerFactory=` to `io.vertx.spi.cluster.impl.zookeeper.ZookeeperClusterManager` in`$VERTX_HOME/bin/vertx`
+- change the value of `-Dvertx.cluster.managerClass=` to `io.vertx.spi.cluster.impl.zookeeper.ZookeeperClusterManager` in`$VERTX_HOME/bin/vertx`
 - make sure you have running zookeeper server.
 - put zookeeper.properties into $VERTX_HOME/conf, you can find default-zookeeper.properties as [example](https://github.com/stream1984/vertx-zookeeper/blob/master/src/main/resources/default-zookeeper.properties)
 - then run your verticle with cmd `vertx -cluster`
 
-If you want clustering with this cluster manager in your Vert.x Maven or Gradle project then just add a dependency to 
-the artifact: io.vertx:vertx-zookeeper:${version}:shaded in your project.  
+#### Add to your Vertx Application
+If you want clustering with this cluster manager in your Vert.x Maven or Gradle project:
+ 
+Maven:
+ 
+```xml
+<dependency>
+              <groupId>io.vertx</groupId>
+              <artifactId>vertx-zookeeper</artifactId>
+              <version>${version}</version>
+</dependency>
+```
 
-You can also specify the cluster manager programmatically if you are embedding Vert.x by specifying it on the options when you are creating your Vert.x instance, 
+Gradle: 
+
+`io.vertx:vertx-zookeeper:${version}`  
+
+#### Using the `-cluster` flag
+
+Be sure to set System Properties:
+ - `-Dvertx.cluster.managerClass=io.vertx.spi.cluster.impl.zookeeper.ZookeeperClusterManager`
+ - `-Dvertx.zookeeper.properties=/path/to/file/zookeeper.properties`
+
+#### Create a Cluster Vertx programmatically 
+
+Specify the cluster manager programmatically if you are embedding Vert.x by specifying it on the options when you are creating your Vert.x instance, 
 for example:
 ```java
 Properties zkConfig = new Properties();

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
   </parent>
 
   <artifactId>vertx-zookeeper</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
 
   <name>Vert.x Zookeeper Cluster Manager</name>
 
   <properties>
-    <stack.version>3.1.0</stack.version>
+    <stack.version>3.2.0</stack.version>
     <curator.version>2.8.0</curator.version>
     <junit.version>4.11</junit.version>
     <log4j.version>1.2.16</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
   </parent>
 
   <artifactId>vertx-zookeeper</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <name>Vert.x Zookeeper Cluster Manager</name>
 
   <properties>
-    <stack.version>3.0.0</stack.version>
+    <stack.version>3.1.0</stack.version>
     <curator.version>2.8.0</curator.version>
     <junit.version>4.11</junit.version>
     <log4j.version>1.2.16</log4j.version>

--- a/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZookeeperClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZookeeperClusterManager.java
@@ -55,13 +55,14 @@ public class ZookeeperClusterManager implements ClusterManager, PathChildrenCach
   private static final String CONFIG_FILE = "zookeeper.properties";
   private Properties conf = new Properties();
 
+  private static final String ZK_SYS_CONFIG_KEY = "vertx.zookeeper.conf";
   private static final String ZK_PATH_LOCKS = "/locks/";
   private static final String ZK_PATH_COUNTERS = "/counters/";
   private static final String ZK_PATH_CLUSTER_NODE = "/cluster/nodes/";
 
   public ZookeeperClusterManager() {
     try {
-      String resourceLocation = System.getProperty("vertx.zookeeper.conf", CONFIG_FILE);
+      String resourceLocation = System.getProperty(ZK_SYS_CONFIG_KEY, CONFIG_FILE);
       conf.load(getConfigStream(resourceLocation));
       log.info("Loaded Zookeeper.properties file from resourceLocation=" + resourceLocation);
     } catch (FileNotFoundException e) {

--- a/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZookeeperClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZookeeperClusterManager.java
@@ -23,6 +23,8 @@ import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -59,7 +61,11 @@ public class ZookeeperClusterManager implements ClusterManager, PathChildrenCach
 
   public ZookeeperClusterManager() {
     try {
-      conf.load(getConfigStream());
+      String resourceLocation = System.getProperty("vertx.zookeeper.conf", CONFIG_FILE);
+      conf.load(getConfigStream(resourceLocation));
+      log.info("Loaded Zookeeper.properties file from resourceLocation=" + resourceLocation);
+    } catch (FileNotFoundException e) {
+      log.error("Could not find zookeeper config file", e);
     } catch (IOException e) {
       log.error("Failed to load zookeeper config", e);
     }
@@ -75,14 +81,17 @@ public class ZookeeperClusterManager implements ClusterManager, PathChildrenCach
     this.curator = curator;
   }
 
-  private InputStream getConfigStream() {
+  private InputStream getConfigStream(String resourceLocation) throws FileNotFoundException {
     ClassLoader ctxClsLoader = Thread.currentThread().getContextClassLoader();
     InputStream is = null;
     if (ctxClsLoader != null) {
-      is = ctxClsLoader.getResourceAsStream(CONFIG_FILE);
+      is = ctxClsLoader.getResourceAsStream(resourceLocation);
     }
-    if (is == null) {
-      is = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE);
+    if (is == null && !resourceLocation.equals(CONFIG_FILE)) {
+      is = new FileInputStream(resourceLocation);
+    }
+    else if (is == null && resourceLocation.equals(CONFIG_FILE)) {
+      is = getClass().getClassLoader().getResourceAsStream(resourceLocation);
       if (is == null) {
         is = getClass().getClassLoader().getResourceAsStream(DEFAULT_CONFIG_FILE);
       }


### PR DESCRIPTION
Updates I made using your library in my application. I needed a way to load the zookeeper properties file at run time from a location on disk outside the classpath. Because we execute java -jar I could not set an additional classpath.

This PR allows a system property to set the location of the zookeeper.properties file using key vertx.zookeeper.conf. Update readme to reflect changes to the vertx cluster manager system property. Use Vertx 3.1