### PR TITLE
fix problem that cause #10 (with updates)

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZKAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZKAsyncMultiMap.java
@@ -1,31 +1,37 @@
 package io.vertx.spi.cluster.impl.zookeeper;
 
 import io.vertx.core.*;
+import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.spi.cluster.AsyncMultiMap;
 import io.vertx.core.spi.cluster.ChoosableIterable;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.TreeCache;
+import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
+import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 /**
  * Created by Stream.Liu
  */
 class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
-  private TreeCache curatorCache;
+
+  private TreeCache treeCache;
+  private ConcurrentMap<String, ChoosableSet<V>> cache = new ConcurrentHashMap<>();
+  private final static String VERTX_SUBS = "__vertx.subs";
 
   ZKAsyncMultiMap(Vertx vertx, CuratorFramework curator, String mapName) {
     super(curator, vertx, ZK_PATH_ASYNC_MULTI_MAP, mapName);
-
-    // /io.vertx/asyncMultiMap/subs
-    curatorCache = new TreeCache(curator, mapPath);
+    treeCache = new TreeCache(curator, mapPath);
+    //we only make a listener for the path of __vertx.subs
+    if (mapName.equals(VERTX_SUBS)) treeCache.getListenable().addListener(new Listener());
     try {
-      curatorCache.start();
+      treeCache.start();
     } catch (Exception e) {
       throw new VertxException(e);
     }
@@ -52,21 +58,28 @@ class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
   @Override
   public void get(K k, Handler<AsyncResult<ChoosableIterable<V>>> asyncResultHandler) {
     if (!keyIsNull(k, asyncResultHandler)) {
-      vertx.runOnContext(event -> {
-        Map<String, ChildData> maps = curatorCache.getCurrentChildren(keyPath(k));
-        ChoosableSet<V> choosableSet = new ChoosableSet<>(0);
-        if (maps != null) {
-          for (ChildData childData : maps.values()) {
-            try {
-              if (childData != null && childData.getData() != null && childData.getData().length > 0)
-                choosableSet.add(asObject(childData.getData()));
-            } catch (Exception ex) {
-              asyncResultHandler.handle(Future.failedFuture(ex));
+      ChoosableSet<V> entries = cache.get(keyPath(k));
+      if (entries != null && !entries.isEmpty()) {
+        asyncResultHandler.handle(Future.succeededFuture(entries));
+      } else {
+        vertx.runOnContext(event -> {
+          Map<String, ChildData> maps = treeCache.getCurrentChildren(keyPath(k));
+          ChoosableSet<V> newEntries = new ChoosableSet<>(0);
+          if (maps != null) {
+            for (ChildData childData : maps.values()) {
+              try {
+                if (childData != null && childData.getData() != null && childData.getData().length > 0) {
+                  newEntries.add(asObject(childData.getData()));
+                }
+              } catch (Exception ex) {
+                asyncResultHandler.handle(Future.failedFuture(ex));
+              }
             }
+            cache.putIfAbsent(keyPath(k), newEntries);
           }
-        }
-        asyncResultHandler.handle(Future.succeededFuture(choosableSet));
-      });
+          asyncResultHandler.handle(Future.succeededFuture(newEntries));
+        });
+      }
     }
   }
 
@@ -82,9 +95,8 @@ class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
     checkExists(valuePath, existEvent -> {
       if (existEvent.succeeded()) {
         if (existEvent.result()) {
-          Optional.ofNullable(curatorCache.getCurrentData(valuePath))
-              .ifPresent(childData ->
-                  delete(valuePath, null, deleteEvent -> forwardAsyncResult(completionHandler, deleteEvent, true)));
+          Optional.ofNullable(treeCache.getCurrentData(valuePath))
+              .ifPresent(childData -> delete(valuePath, null, deleteEvent -> forwardAsyncResult(completionHandler, deleteEvent, true)));
         } else {
           vertx.runOnContext(event -> completionHandler.handle(Future.succeededFuture(false)));
         }
@@ -97,10 +109,10 @@ class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
   @Override
   public void removeAllForValue(V v, Handler<AsyncResult<Void>> completionHandler) {
     Collection<String> valuePaths = new ArrayList<>();
-    Optional.ofNullable(curatorCache.getCurrentChildren(mapPath)).ifPresent(childDataMap -> {
+    Optional.ofNullable(treeCache.getCurrentChildren(mapPath)).ifPresent(childDataMap -> {
       childDataMap.keySet().forEach(keyPath ->
-          curatorCache.getCurrentChildren(mapPath + "/" + keyPath).keySet().forEach(valuePath ->
-              Optional.ofNullable(curatorCache.getCurrentData(mapPath + "/" + keyPath + "/" + valuePath))
+          treeCache.getCurrentChildren(mapPath + "/" + keyPath).keySet().forEach(valuePath ->
+              Optional.ofNullable(treeCache.getCurrentData(mapPath + "/" + keyPath + "/" + valuePath))
                   .filter(childData -> Optional.of(childData.getData()).isPresent())
                   .ifPresent(childData -> {
                     try {
@@ -120,6 +132,44 @@ class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
         }
       }));
     });
+  }
+
+
+  private Map.Entry<String, V> getServerID(ChildData childData) {
+    String[] paths = childData.getPath().split("/");
+    String[] hostAndPort = paths[paths.length - 1].split(":");
+    ServerID serverID = new ServerID(Integer.valueOf(hostAndPort[1]), hostAndPort[0]);
+    Map<String, V> result = new HashMap<>(1);
+    String keyPath = Stream.of(paths).limit(paths.length - 1).reduce((previous, current) -> previous + "/" + current).get();
+    result.put(keyPath, (V) serverID);
+    return result.entrySet().iterator().next();
+  }
+
+  private class Listener implements TreeCacheListener {
+    @Override
+    public void childEvent(CuratorFramework client, TreeCacheEvent treeCacheEvent) throws Exception {
+      ChildData childData;
+      switch (treeCacheEvent.getType()) {
+        case NODE_ADDED:
+          childData = treeCacheEvent.getData();
+          if (childData != null && childData.getData() != null && childData.getData().length > 0) {
+            Map.Entry<String, V> entry = getServerID(childData);
+            ChoosableSet<V> entries = Optional.ofNullable(cache.get(entry.getKey())).orElse(new ChoosableSet<>(1));
+            entries.add(entry.getValue());
+            cache.put(entry.getKey(), entries);
+          }
+          break;
+        case NODE_REMOVED:
+          childData = treeCacheEvent.getData();
+          if (childData != null && childData.getPath() != null) {
+            Map.Entry<String, V> entry = getServerID(childData);
+            ChoosableSet<V> entries = Optional.ofNullable(cache.get(entry.getKey())).orElse(new ChoosableSet<>(0));
+            entries.remove(entry.getValue());
+            cache.put(entry.getKey(), entries);
+          }
+          break;
+      }
+    }
   }
 
 }

--- a/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZKAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/impl/zookeeper/ZKAsyncMultiMap.java
@@ -1,7 +1,6 @@
 package io.vertx.spi.cluster.impl.zookeeper;
 
 import io.vertx.core.*;
-import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.spi.cluster.AsyncMultiMap;
 import io.vertx.core.spi.cluster.ChoosableIterable;
 import org.apache.curator.framework.CuratorFramework;
@@ -14,22 +13,19 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 /**
  * Created by Stream.Liu
  */
 class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
-
   private TreeCache treeCache;
   private ConcurrentMap<String, ChoosableSet<V>> cache = new ConcurrentHashMap<>();
-  private final static String VERTX_SUBS = "__vertx.subs";
 
   ZKAsyncMultiMap(Vertx vertx, CuratorFramework curator, String mapName) {
     super(curator, vertx, ZK_PATH_ASYNC_MULTI_MAP, mapName);
     treeCache = new TreeCache(curator, mapPath);
-    //we only make a listener for the path of __vertx.subs
-    if (mapName.equals(VERTX_SUBS)) treeCache.getListenable().addListener(new Listener());
+    treeCache.getListenable().addListener(new Listener());
+
     try {
       treeCache.start();
     } catch (Exception e) {
@@ -64,7 +60,7 @@ class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
       } else {
         vertx.runOnContext(event -> {
           Map<String, ChildData> maps = treeCache.getCurrentChildren(keyPath(k));
-          ChoosableSet<V> newEntries = new ChoosableSet<>(0);
+          ChoosableSet<V> newEntries = new ChoosableSet<>(maps != null ? maps.size(): 0);
           if (maps != null) {
             for (ChildData childData : maps.values()) {
               try {
@@ -134,38 +130,41 @@ class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<K, V> {
     });
   }
 
-
-  private Map.Entry<String, V> getServerID(ChildData childData) {
-    String[] paths = childData.getPath().split("/");
-    String[] hostAndPort = paths[paths.length - 1].split(":");
-    ServerID serverID = new ServerID(Integer.valueOf(hostAndPort[1]), hostAndPort[0]);
-    Map<String, V> result = new HashMap<>(1);
-    String keyPath = Stream.of(paths).limit(paths.length - 1).reduce((previous, current) -> previous + "/" + current).get();
-    result.put(keyPath, (V) serverID);
-    return result.entrySet().iterator().next();
-  }
-
   private class Listener implements TreeCacheListener {
+    private String cachePath(final String key) {
+      return mapPath + "/" + key;
+    }
+
     @Override
     public void childEvent(CuratorFramework client, TreeCacheEvent treeCacheEvent) throws Exception {
-      ChildData childData;
+      final ChildData childData = treeCacheEvent.getData();
+      // We only care about events with childData: NODE_ADDED, NODE_REMOVED
+      if (childData == null || mapPath.length() == childData.getPath().length()) {
+        return;
+      }
+      // Strip off the map prefix and leave the multi-map key path: `<parent>/<child>`
+      final String key[] = childData.getPath().substring(mapPath.length() + 1).split("/", 2);
+      final ChoosableSet<V> entries = cache.computeIfAbsent(cachePath(key[0]), k -> new ChoosableSet<>(1));
+
+      // When we only have 1 item in the key[], we're operating on the entire key (e.g. removing it)
+      // rather than a child element under the key
       switch (treeCacheEvent.getType()) {
         case NODE_ADDED:
-          childData = treeCacheEvent.getData();
-          if (childData != null && childData.getData() != null && childData.getData().length > 0) {
-            Map.Entry<String, V> entry = getServerID(childData);
-            ChoosableSet<V> entries = Optional.ofNullable(cache.get(entry.getKey())).orElse(new ChoosableSet<>(1));
-            entries.add(entry.getValue());
-            cache.put(entry.getKey(), entries);
+          if (key.length > 1) {
+            entries.add(asObject(childData.getData()));
           }
           break;
         case NODE_REMOVED:
-          childData = treeCacheEvent.getData();
-          if (childData != null && childData.getPath() != null) {
-            Map.Entry<String, V> entry = getServerID(childData);
-            ChoosableSet<V> entries = Optional.ofNullable(cache.get(entry.getKey())).orElse(new ChoosableSet<>(0));
-            entries.remove(entry.getValue());
-            cache.put(entry.getKey(), entries);
+          if (key.length == 1) {
+            cache.remove(cachePath(key[0]));
+          } else {
+            // When the child items are serialized into ZK, we use `toString()` to build the path
+            // element. When removing, search for the item that has the expected string representation.
+            for (final V entry: entries) {
+              if (entry.toString().equals(key[1])) {
+                entries.remove(entry);
+              }
+            }
           }
           break;
       }


### PR DESCRIPTION
This is based on the work by @stream1984 in PR #12. While doing a review and testing locally, I ended up making a number of changes...rather than merely commenting, I thought it might be useful to share the changes.

This merely allows us to use the clustering and get the pseudo-roundrobin EB message distribution mentioned in #10. I suspect there still some bugs to work-on based on the test feedback. In particular, it looks like the code keeps curator objects open, and connected, even after the node has left the cluster...this is likely a problem. 
