### PR TITLE
Fail put/putIfAbsent ttl variants with UnsupportedOperationException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <name>Vert.x Zookeeper Cluster Manager</name>
 
   <properties>
-    <stack.version>3.3.3</stack.version>
+    <stack.version>3.4.0-SNAPSHOT</stack.version>
     <curator.version>2.11.0</curator.version>
     <junit.version>4.11</junit.version>
     <log4j.version>1.2.16</log4j.version>

--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKAsyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKAsyncMap.java
@@ -15,7 +15,12 @@
  */
 package io.vertx.spi.cluster.zookeeper.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.TimeoutStream;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.shareddata.AsyncMap;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
@@ -76,9 +81,7 @@ public class ZKAsyncMap<K, V> extends ZKMap<K, V> implements AsyncMap<K, V> {
 
   @Override
   public void put(K k, V v, long timeout, Handler<AsyncResult<Void>> completionHandler) {
-    TimeoutStream timeoutStream = vertx.timerStream(timeout);
-    timeoutStream.handler(aLong -> completionHandler.handle(Future.failedFuture("timeout on method put.")));
-    put(k, v, Optional.of(timeoutStream), completionHandler);
+    completionHandler.handle(Future.failedFuture(new UnsupportedOperationException()));
   }
 
   private void put(K k, V v, Optional<TimeoutStream> timeoutStream, Handler<AsyncResult<Void>> completionHandler) {
@@ -102,9 +105,7 @@ public class ZKAsyncMap<K, V> extends ZKMap<K, V> implements AsyncMap<K, V> {
 
   @Override
   public void putIfAbsent(K k, V v, long timeout, Handler<AsyncResult<V>> completionHandler) {
-    TimeoutStream timeoutStream = vertx.timerStream(timeout);
-    timeoutStream.handler(aLong -> completionHandler.handle(Future.failedFuture("timeout on method putIfAbsent.")));
-    putIfAbsent(k, v, Optional.of(timeoutStream), completionHandler);
+    completionHandler.handle(Future.failedFuture(new UnsupportedOperationException()));
   }
 
   private void putIfAbsent(K k, V v, Optional<TimeoutStream> timeoutStream, Handler<AsyncResult<V>> completionHandler) {

--- a/src/test/java/io/vertx/test/core/ZKClusteredWideMapTest.java
+++ b/src/test/java/io/vertx/test/core/ZKClusteredWideMapTest.java
@@ -2,6 +2,9 @@ package io.vertx.test.core;
 
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.zookeeper.MockZKCluster;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
 
 /**
  *
@@ -20,5 +23,27 @@ public class ZKClusteredWideMapTest extends ClusterWideMapTestDifferentNodes {
     return zkClustered.getClusterManager();
   }
 
+  @Override
+  @Test
+  public void testMapPutTtl() {
+    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
+      map.put("k", "v", 13, onFailure(cause -> {
+        assertThat(cause, instanceOf(UnsupportedOperationException.class));
+        testComplete();
+      }));
+    }));
+    await();
+  }
 
+  @Override
+  @Test
+  public void testMapPutIfAbsentTtl() {
+    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
+      map.putIfAbsent("k", "v", 13, onFailure(cause -> {
+        assertThat(cause, instanceOf(UnsupportedOperationException.class));
+        testComplete();
+      }));
+    }));
+    await();
+  }
 }


### PR DESCRIPTION
Zookeeper CM does not support this and the current implementation does not let you know.

It seems there was a misunderstanding about the ttl parameter goal.
It is not a timeout for the cache operation, but the lifespan for this specific cache entry.