### PR TITLE
make cluster manager more robust while network unstable.

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKMap.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKMap.java
@@ -45,7 +45,7 @@ abstract class ZKMap<K, V> {
 
   static final String ZK_PATH_ASYNC_MAP = "asyncMap";
   static final String ZK_PATH_ASYNC_MULTI_MAP = "asyncMultiMap";
-  private static final String EVENTBUS_PATH = "/" + ZK_PATH_ASYNC_MULTI_MAP + "/__vertx.subs/";
+  static final String EVENTBUS_PATH = "/" + ZK_PATH_ASYNC_MULTI_MAP + "/__vertx.subs/";
   static final String ZK_PATH_SYNC_MAP = "syncMap";
 
   private RetryPolicy retryPolicy = new ExponentialBackoffRetry(100, 5);

--- a/src/test/java/io/vertx/test/core/ZKClusteredWideMapTest.java
+++ b/src/test/java/io/vertx/test/core/ZKClusteredWideMapTest.java
@@ -2,9 +2,6 @@ package io.vertx.test.core;
 
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.zookeeper.MockZKCluster;
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.*;
 
 /**
  *
@@ -23,27 +20,4 @@ public class ZKClusteredWideMapTest extends ClusterWideMapTestDifferentNodes {
     return zkClustered.getClusterManager();
   }
 
-  @Override
-  @Test
-  public void testMapPutTtl() {
-    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
-      map.put("k", "v", 13, onFailure(cause -> {
-        assertThat(cause, instanceOf(UnsupportedOperationException.class));
-        testComplete();
-      }));
-    }));
-    await();
-  }
-
-  @Override
-  @Test
-  public void testMapPutIfAbsentTtl() {
-    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
-      map.putIfAbsent("k", "v", 13, onFailure(cause -> {
-        assertThat(cause, instanceOf(UnsupportedOperationException.class));
-        testComplete();
-      }));
-    }));
-    await();
-  }
 }


### PR DESCRIPTION
Our team have come across such situation that eb address info will be removed while network unstable, this PR make a snapshot for eb address info , and will restore them while node have reconnect to the zk cluster.

Signed-off-by: stream <stream1984@gmail.com>