### PR TITLE
fix __vertx.haInfo children do not remove while kill -9

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKSyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKSyncMap.java
@@ -18,6 +18,7 @@ package io.vertx.spi.cluster.zookeeper.impl;
 import com.google.common.collect.Maps;
 import io.vertx.core.VertxException;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 
 import java.io.Serializable;
@@ -106,7 +107,8 @@ public class ZKSyncMap<K, V> extends ZKMap<K, V> implements Map<K, V> {
       if (get(key) != null) {
         curator.setData().forPath(keyPath, valueBytes);
       } else {
-        curator.create().creatingParentsIfNeeded().forPath(keyPath, valueBytes);
+        //sync map's node mode should be EPHEMERAL, as lifecycle of this path as long as verticle's.
+        curator.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(keyPath, valueBytes);
       }
       return value;
     } catch (Exception e) {

--- a/src/test/java/io/vertx/spi/cluster/zookeeper/ZKSyncMapTest.java
+++ b/src/test/java/io/vertx/spi/cluster/zookeeper/ZKSyncMapTest.java
@@ -9,9 +9,7 @@ import org.apache.curator.test.TestingServer;
 import org.apache.curator.test.Timing;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -54,6 +52,10 @@ public class ZKSyncMapTest {
       assertEquals(k, entry.getKey());
       assertEquals(v, entry.getValue());
     });
+
+    String value = syncMap.remove(k);
+    assertEquals(value, v);
+    assertNull(syncMap.get(k));
 
     syncMap.clear();
     assertTrue(syncMap.isEmpty());


### PR DESCRIPTION
We found a lot of children nodes in __vertx.haInfo, even these nodes have been closed, this PR make nodes under of __vertx.haInfo as ephemeral type.
Signed-off-by: stream <stream1984@gmail.com>