### PR TITLE
Fixes testNoHandlersCallbackContext

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -10,7 +10,7 @@ This implementation is packaged inside:
 <dependency>
 <groupId>io.vertx</groupId>
 <artifactId>vertx-zookeeper</artifactId>
-<version>3.4.1</version>
+<version>3.4.2-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -41,7 +41,7 @@ you can find all the vert.x node information in path of `/io.vertx/cluster/nodes
 
 == Using this cluster manager
 
-If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named `vertx-zookeeper-3.4.1`.jar`
+If you are using Vert.x from the command line, the jar corresponding to this cluster manager (it will be named `vertx-zookeeper-3.4.2-SNAPSHOT`.jar`
 should be in the `lib` directory of the Vert.x installation.
 
 If you want clustering with this cluster manager in your Vert.x Maven or Gradle project then just add a dependency to

--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKAsyncMultiMap.java
@@ -17,6 +17,7 @@ package io.vertx.spi.cluster.zookeeper.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -98,6 +99,7 @@ public class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<
 
   @Override
   public void get(K k, Handler<AsyncResult<ChoosableIterable<V>>> asyncResultHandler) {
+    Context ctx = vertx.getOrCreateContext();
     assertKeyIsNotNull(k)
       .compose(aVoid -> {
         final String keyPath = keyPath(k);
@@ -124,7 +126,7 @@ public class ZKAsyncMultiMap<K, V> extends ZKMap<K, V> implements AsyncMultiMap<
         }
         return future;
       })
-      .setHandler(asyncResultHandler);
+      .setHandler(ar -> ctx.runOnContext(v -> asyncResultHandler.handle(ar)));
   }
 
   @Override


### PR DESCRIPTION
When calling eventBus#send from executeBlocking, the callback should be executed on the context thread.