### PR TITLE
bugfix: future.complete() Result is already complete: failed

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/zookeeper/ZookeeperClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/ZookeeperClusterManager.java
@@ -278,10 +278,10 @@ public class ZookeeperClusterManager implements ClusterManager, PathChildrenCach
         if (customCuratorCluster) {
           try {
             addLocalNodeID();
+            future.complete();
           } catch (VertxException e) {
             future.fail(e);
           }
-          future.complete();
           return;
         }
 
@@ -318,10 +318,10 @@ public class ZookeeperClusterManager implements ClusterManager, PathChildrenCach
         nodeID = UUID.randomUUID().toString();
         try {
           addLocalNodeID();
+          future.complete();
         } catch (Exception e) {
           future.fail(e);
         }
-        future.complete();
       }
     }, resultHandler);
   }


### PR DESCRIPTION
when exception occur future.fail(e); but future.complete(); again .

java.lang.IllegalStateException: Result is already complete: failed
at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:121) ~[vertx-core-3.4.1.jar:?]