### PR TITLE
Updated Zookeeper version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.9</version>
+      <version>3.4.13</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrading the vertx-kafka-client to use newer version of the native Kafka client (2.1.0) will take a conflict on Zookeeper dependency with this component.
This upgrade is needed for fixing the conflict.