### PR TITLE
Upgrade log4j and slf4j dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <zookeeper.version>3.5.9</zookeeper.version>
     <guava.version>30.1.1-jre</guava.version>
     <junit.version>4.13.1</junit.version>
-    <slf4j.version>1.7.25</slf4j.version>
-    <log4j.version>1.2.17</log4j.version>
+    <slf4j.version>1.7.21</slf4j.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
@@ -143,14 +143,14 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION

Motivation:

This commit upgrades the log4j and slf4j dependencies to those of vertx-core. The following vulnerabilities are resolved with this commit.

pkg:maven/log4j/log4j@1.2.17
- [CVE-2019-17571] CWE-502: Deserialization of Untrusted Data
- [CVE-2022-23305] CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
- [CVE-2022-23302] CWE-502: Deserialization of Untrusted Data
- [CVE-2022-23307] CWE-502: Deserialization of Untrusted Data
- [sonatype-2010-0053] CWE-426: Untrusted Search Path
- [CVE-2021-4104] CWE-502: Deserialization of Untrusted Data

Conformance:

My commits are signed and I have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
