### PR TITLE
#124 Update curator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
 
   <properties>
     <stack.version>4.4.0-SNAPSHOT</stack.version>
-    <curator.version>4.3.0</curator.version>
-    <zookeeper.version>3.5.9</zookeeper.version>
-    <junit.version>4.13.1</junit.version>
+    <curator.version>5.4.0</curator.version>
+    <zookeeper.version>3.7.1</zookeeper.version>
+    <junit.version>5.6.2</junit.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
@@ -150,8 +150,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <stack.version>4.4.0-SNAPSHOT</stack.version>
     <curator.version>5.4.0</curator.version>
     <zookeeper.version>3.7.1</zookeeper.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>4.13.1</junit.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
@@ -150,14 +150,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
@@ -170,6 +164,10 @@
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
- updated zookeeper to latest stable (3.7.1)
- updated curator to latest (5.4.0)
- upgraded junit + added junit vintage due to a clash with curator-test

Motivation:

curator-framework version is quite outdated and have vulnerabilities as shown in ticket #124
I therefore updated both version of curator-framework as well as zookeeper.

Because curator-test migrated to junit5, I had to bump versio to junit to 5 as well and included a dependency on junit-vintage to ensure tests were still working

Conformance:
- commit signed
- contrinbutor agreement signed
