### PR TITLE
#128 accumulating nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
 
   <properties>
     <stack.version>4.4.0-SNAPSHOT</stack.version>
-    <curator.version>4.3.0</curator.version>
-    <zookeeper.version>3.5.9</zookeeper.version>
-    <junit.version>4.13.1</junit.version>
+    <curator.version>5.4.0</curator.version>
+    <zookeeper.version>3.7.1</zookeeper.version>
+    <junit.version>5.6.2</junit.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
@@ -150,8 +150,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <stack.version>4.4.0-SNAPSHOT</stack.version>
     <curator.version>5.4.0</curator.version>
     <zookeeper.version>3.7.1</zookeeper.version>
-    <junit.version>5.6.2</junit.version>
+    <junit.version>4.13.1</junit.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
@@ -150,14 +150,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
@@ -170,6 +164,10 @@
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/SubsMapHelper.java
@@ -69,7 +69,7 @@ public class SubsMapHelper implements TreeCacheListener {
       try {
         Buffer buffer = Buffer.buffer();
         registrationInfo.writeToBuffer(buffer);
-        curator.create().orSetData().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).inBackground((c, e) -> {
+        curator.create().orSetData().creatingParentContainersIfNeeded().withMode(CreateMode.EPHEMERAL).inBackground((c, e) -> {
           if (e.getType() == CuratorEventType.CREATE || e.getType() == CuratorEventType.SET_DATA) {
             vertx.runOnContext(Avoid -> {
               ownSubs.compute(address, (add, curr) -> addToSet(registrationInfo, curr));
@@ -140,6 +140,7 @@ public class SubsMapHelper implements TreeCacheListener {
           }
         }).forPath(fullPath.apply(address, registrationInfo));
       }
+
     } catch (Exception e) {
       log.error(String.format("remove subs address %s failed.", address), e);
       promise.fail(e);


### PR DESCRIPTION
Motivation:

Fix for #128 

We have a scenario where we have multiple verticles which are used to index large sets of data.
each verticle register a consumer on an address such "indexing.<session_id>" where the session id is a uuid (dynamic)
once the indexing is done the consumer are unregistered and properly deleted, but the parent node not removed.

Using a Container as Parent solves the issue.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
