### PR TITLE
Fix #128 accumulating nodes

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/SubsMapHelper.java
@@ -69,7 +69,7 @@ public class SubsMapHelper implements TreeCacheListener {
       try {
         Buffer buffer = Buffer.buffer();
         registrationInfo.writeToBuffer(buffer);
-        curator.create().orSetData().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).inBackground((c, e) -> {
+        curator.create().orSetData().creatingParentContainersIfNeeded().withMode(CreateMode.EPHEMERAL).inBackground((c, e) -> {
           if (e.getType() == CuratorEventType.CREATE || e.getType() == CuratorEventType.SET_DATA) {
             vertx.runOnContext(Avoid -> {
               ownSubs.compute(address, (add, curr) -> addToSet(registrationInfo, curr));


### PR DESCRIPTION

Motivation:

Fix for https://github.com/vert-x3/vertx-zookeeper/issues/128

We have a scenario where we have multiple verticles which are used to index large sets of data.
each verticle register a consumer on an address such "indexing.<session_id>" where the session id is a uuid (dynamic)
once the indexing is done the consumer are unregistered and properly deleted, but the parent node not removed.

Using a Container as Parent solves the issue.
Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
