### PR TITLE
add a way to configure the retry policy using json file.

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -103,6 +103,25 @@ You can also specify configuration programmatically if embedding:
 {@link example.Examples#example2()}
 ----
 
+The retry policy can be specified in the json configuration as following:
+
+[source,json]
+{
+  "retry":{
+    "policy": "exponential_backoff"
+  }
+}
+
+the possible value for the policy are:
+
+* exponential_backoff (default)
+* bounded_exponential_backoff
+* one_time
+* n_times
+* forever
+* until_elapsed
+
+
 IMPORTANT: You can also configure the zookeeper hosts using the `vertx.zookeeper.hosts` system property.
 
 === Enabling logging

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -106,11 +106,13 @@ You can also specify configuration programmatically if embedding:
 The retry policy can be specified in the json configuration as following:
 
 [source,json]
+----
 {
   "retry":{
     "policy": "exponential_backoff"
   }
 }
+----
 
 the possible value for the policy are:
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -114,14 +114,14 @@ The retry policy can be specified in the json configuration as following:
 }
 ----
 
-the possible value for the policy are:
+The possible value for the policy are:
 
-* exponential_backoff (default)
-* bounded_exponential_backoff
-* one_time
-* n_times
-* forever
-* until_elapsed
+* `exponential_backoff` (default)
+* `bounded_exponential_backoff`
+* `one_time`
+* `n_times`
+* `forever`
+* `until_elapsed`
 
 
 IMPORTANT: You can also configure the zookeeper hosts using the `vertx.zookeeper.hosts` system property.

--- a/src/main/java/io/vertx/spi/cluster/zookeeper/ZookeeperClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/ZookeeperClusterManager.java
@@ -33,12 +33,7 @@ import io.vertx.core.spi.cluster.NodeInfo;
 import io.vertx.core.spi.cluster.NodeListener;
 import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationInfo;
-import io.vertx.spi.cluster.zookeeper.impl.ConfigUtil;
-import io.vertx.spi.cluster.zookeeper.impl.SubsMapHelper;
-import io.vertx.spi.cluster.zookeeper.impl.ZKAsyncMap;
-import io.vertx.spi.cluster.zookeeper.impl.ZKCounter;
-import io.vertx.spi.cluster.zookeeper.impl.ZKLock;
-import io.vertx.spi.cluster.zookeeper.impl.ZKSyncMap;
+import io.vertx.spi.cluster.zookeeper.impl.*;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -292,10 +287,7 @@ public class ZookeeperClusterManager implements ClusterManager, PathChildrenCach
         }
 
         if (curator == null) {
-          retryPolicy = new ExponentialBackoffRetry(
-            conf.getJsonObject("retry", new JsonObject()).getInteger("initialSleepTime", 1000),
-            conf.getJsonObject("retry", new JsonObject()).getInteger("maxTimes", 5),
-            conf.getJsonObject("retry", new JsonObject()).getInteger("intervalTimes", 10000));
+          retryPolicy = RetryPolicyHelper.createRetryPolicy(conf.getJsonObject("retry", new JsonObject()));
 
           // Read the zookeeper hosts from a system variable
           String hosts = System.getProperty("vertx.zookeeper.hosts");

--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/RetryPolicyHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/RetryPolicyHelper.java
@@ -1,0 +1,44 @@
+package io.vertx.spi.cluster.zookeeper.impl;
+
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.json.JsonObject;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.retry.*;
+
+public class RetryPolicyHelper {
+  private static final String DEFAULT_RETRY_POLICY = "exponential_backoff";
+  private static final Logger log = LoggerFactory.getLogger(RetryPolicyHelper.class);
+
+
+  /**
+   * creates a {@link RetryPolicy} based on a JsonObject configuration.
+   * It falls back to {@link ExponentialBackoffRetry} if no valid policy is specified.
+   *
+   * @param conf the configuration object
+   * @return RetryPolicy instance
+   */
+  public static RetryPolicy createRetryPolicy(JsonObject conf){
+    String policy = conf.getString("policy", DEFAULT_RETRY_POLICY);
+    int initialSleepTime = conf.getInteger("initialSleepTime", 1000);
+    int maxTimes = conf.getInteger("maxTimes", 5);
+    int intervalTimes = conf.getInteger("intervalTimes",10000);
+
+    switch (policy){
+      case "bounded_exponential_backoff": return new BoundedExponentialBackoffRetry(initialSleepTime,maxTimes,intervalTimes);
+      case "one_time": return new RetryOneTime(intervalTimes);
+      case "n_times": return new RetryNTimes(maxTimes, intervalTimes);
+      case "forever": return new RetryForever(intervalTimes);
+      case "until_elapsed": return new RetryUntilElapsed(maxTimes,intervalTimes);
+      case DEFAULT_RETRY_POLICY: return new ExponentialBackoffRetry(initialSleepTime, maxTimes, intervalTimes);
+      default: {
+        log.warn(String.format("%s is not a valid policy, falling back to %s",policy, DEFAULT_RETRY_POLICY));
+        return new ExponentialBackoffRetry(initialSleepTime, maxTimes, intervalTimes);
+      }
+    }
+  }
+
+  private RetryPolicyHelper() {
+    //Utility class
+  }
+}

--- a/src/main/resources/default-zookeeper.json
+++ b/src/main/resources/default-zookeeper.json
@@ -4,6 +4,7 @@
   "connectTimeout":3000,
   "rootPath":"io.vertx",
   "retry": {
+    "policy": "exponential_backoff",
     "initialSleepTime":100,
     "intervalTimes":10000,
     "maxTimes":5

--- a/src/test/java/io/vertx/core/ProgrammaticZKClusterManagerTest.java
+++ b/src/test/java/io/vertx/core/ProgrammaticZKClusterManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryOneTime;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -68,6 +69,35 @@ public class ProgrammaticZKClusterManagerTest extends AsyncTestBase {
     JsonObject config = zkCluster.getDefaultConfig();
     ZookeeperClusterManager mgr = new ZookeeperClusterManager(config);
     testProgrammatic(mgr, config);
+  }
+
+  @Test
+  public void testProgrammaticSetRetryPolicyDefault() throws Exception {
+    JsonObject config = zkCluster.getDefaultConfig();
+    ZookeeperClusterManager mgr = new ZookeeperClusterManager(config);
+    VertxOptions options = new VertxOptions().setClusterManager(mgr);
+    Vertx.clusteredVertx(options).onComplete(res -> {
+      assertTrue(res.succeeded());
+      assertNotNull(mgr.getCuratorFramework());
+      assertTrue(mgr.getCuratorFramework().getZookeeperClient().getRetryPolicy() instanceof ExponentialBackoffRetry);
+      testComplete();
+    });
+    await();
+  }
+
+  public void testProgrammaticSetRetryPolicy() throws Exception {
+    JsonObject config = zkCluster.getDefaultConfig();
+    config.put("retry", new JsonObject().put("policy","one_time"));
+
+    ZookeeperClusterManager mgr = new ZookeeperClusterManager(config);
+    VertxOptions options = new VertxOptions().setClusterManager(mgr);
+    Vertx.clusteredVertx(options).onComplete(res -> {
+      assertTrue(res.succeeded());
+      assertNotNull(mgr.getCuratorFramework());
+      assertTrue(mgr.getCuratorFramework().getZookeeperClient().getRetryPolicy() instanceof RetryOneTime);
+      testComplete();
+    });
+    await();
   }
 
   @Test

--- a/src/test/java/io/vertx/spi/cluster/zookeeper/RetryPolicyTest.java
+++ b/src/test/java/io/vertx/spi/cluster/zookeeper/RetryPolicyTest.java
@@ -1,0 +1,27 @@
+package io.vertx.spi.cluster.zookeeper;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.spi.cluster.zookeeper.impl.RetryPolicyHelper;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.retry.RetryOneTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RetryPolicyTest {
+
+  @Test
+  public void createDefaultRetryPolicy(){
+    JsonObject config = new JsonObject();
+    RetryPolicy policy = RetryPolicyHelper.createRetryPolicy(config);
+    Assert.assertTrue(policy instanceof ExponentialBackoffRetry);
+  }
+
+  @Test
+  public void createOneTimeRetryPolicy(){
+    JsonObject config = new JsonObject().put("policy","one_time");
+    RetryPolicy policy = RetryPolicyHelper.createRetryPolicy(config);
+    Assert.assertTrue(policy instanceof RetryOneTime);
+  }
+
+}


### PR DESCRIPTION
Motivation:

Right now the RetryPolicy is hardcoded (ExponentialBackoffRetryPolicy) and the only way to override this is buy providing directly a CuratorFramework instance when creating a ZookeeperClusterManager.

It is a bit overkill to do so when someone simply want to change the retry policy (for something like retry forever for retry elapsed or retry forever for example).

This pull request provide a simple mechanism to enable a user to provide a "policy" setting within the retry configuration, which will then be used in the ZookeeperClusterManager

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
