### PR TITLE
 Removed deprecated ClusterSerializable support

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKMap.java
+++ b/src/main/java/io/vertx/spi/cluster/zookeeper/impl/ZKMap.java
@@ -20,7 +20,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.shareddata.impl.ClusterSerializable;
+import io.vertx.core.shareddata.ClusterSerializable;
 import org.apache.curator.RetryLoop;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;


### PR DESCRIPTION
Follows-up on eclipse-vertx/vert.x#4739